### PR TITLE
feat: GrowthMate banner on create page

### DIFF
--- a/src/routes/(memecooking)/create/+page.svelte
+++ b/src/routes/(memecooking)/create/+page.svelte
@@ -9,6 +9,7 @@
   import { z } from "zod";
 
   import FgBanner from "./FGBanner.svelte";
+  import GrowthMateBanner from "./GrowthMateBanner.svelte";
   import NewMemePreview from "./NewMemePreview.svelte";
   import SoftcapDefault, { CAP_DEFAULT_OPTIONS } from "./SoftcapDefault.svelte";
   import TeamAllocationToggle from "./TeamAllocationToggle.svelte";
@@ -650,6 +651,9 @@
             </div>
           </details>
         </div>
+
+        <!-- GrowthMate Banner -->
+        <GrowthMateBanner />
 
         <!-- Create Token Card -->
         <div class="bg-gray-800 rounded-lg p-4 space-y-4">

--- a/src/routes/(memecooking)/create/GrowthMateBanner.svelte
+++ b/src/routes/(memecooking)/create/GrowthMateBanner.svelte
@@ -1,0 +1,34 @@
+<div
+  class="my-6 flex items-start gap-4 rounded-lg border p-4 bg-gray-800 border-shitzu-500 border-2"
+>
+  <div class="flex-shrink-0 text-shitzu-500">
+    <svg
+      xmlns="http://www.w3.org/2000/svg"
+      width="24"
+      height="24"
+      viewBox="0 0 24 24"
+      fill="none"
+      stroke="currentColor"
+      stroke-width="2"
+      stroke-linecap="round"
+      stroke-linejoin="round"
+      class="icon icon-tabler icons-tabler-outline icon-tabler-bulb"
+      ><path stroke="none" d="M0 0h24v24H0z" fill="none" /><path
+        d="M3 12h1m8 -9v1m8 8h1m-15.4 -6.4l.7 .7m12.1 -.7l-.7 .7"
+      /><path
+        d="M9 16a5 5 0 1 1 6 0a3.5 3.5 0 0 0 -1 3a2 2 0 0 1 -4 0a3.5 3.5 0 0 0 -1 -3"
+      /><path d="M9.7 17l4.6 0" /></svg
+    >
+  </div>
+  <div class="flex-1">
+    <h4 class="text-shitzu-500 font-bold mb-1">A note on awareness</h4>
+    <p class="text-sm text-shitzu-200">
+      Memecoins need strong marketing. Reach thousands of memecoin traders
+      through ads on meme.cooking and other NEAR dapps. Set up your campaign on <a
+        class="text-shitzu-500 underline"
+        href="https://app.growthmate.xyz"
+        target="_blank">GrowthMate</a
+      >.
+    </p>
+  </div>
+</div>


### PR DESCRIPTION
Adds an info box on the token creation page.
It suggests that the token creator launches a campaign to boost awareness for their token.

![image](https://github.com/user-attachments/assets/177a8d1a-f5e6-4efd-8003-293c8e548074)

